### PR TITLE
Use android.view package instead of android.widget when injecting a View

### DIFF
--- a/src/eu/inmite/android/plugin/butterknifezelezny/common/Defintions.java
+++ b/src/eu/inmite/android/plugin/butterknifezelezny/common/Defintions.java
@@ -11,6 +11,7 @@ public class Defintions {
 	static {
 		// special classes; default package is android.widget.*
 		paths.put("WebView", "android.webkit.WebView");
+		paths.put("View", "android.view.View");
 
 		// adapters
 		adapters.add("android.widget.ListAdapter");


### PR DESCRIPTION
When attempting to generate injections with a View class, the plugin imports `com.widget.View` instead of `android.view.View`. This pull request fixes it.

Fixes issue #13.
