### PR TITLE
Pass InjectWriter contsructor parameters in the correct order

### DIFF
--- a/src/eu/inmite/android/plugin/butterknifezelezny/InjectAction.java
+++ b/src/eu/inmite/android/plugin/butterknifezelezny/InjectAction.java
@@ -88,7 +88,7 @@ public class InjectAction extends BaseGenerateAction implements IConfirmListener
 		}
 
 		if (cnt > 0) { // generate injections
-			new InjectWriter(file, getTargetClass(editor, file), "Generate Injections", elements, fieldNamePrefix, layout.getName(), createHolder).execute();
+			new InjectWriter(file, getTargetClass(editor, file), "Generate Injections", elements, layout.getName(), fieldNamePrefix, createHolder).execute();
 
 			if (cnt == 1) {
 				Utils.showInfoNotification(project, "One injection added to " + file.getName());


### PR DESCRIPTION
Previously `InjectWriter` constructor params were passed in the incorrect order that caused generating a Javadoc for the view holder class with 'null' instead of a real layout file name:

/**
     \* This class contains all butterknife-injected Views & Layouts from layout file 'null'
     \* for easy to all layout elements.
...
**/

This PR fixes it.
