### PR TITLE
Allow an empty member prefix.

### DIFF
--- a/src/eu/inmite/android/plugin/butterknifezelezny/common/Utils.java
+++ b/src/eu/inmite/android/plugin/butterknifezelezny/common/Utils.java
@@ -246,21 +246,18 @@ public class Utils {
 	 * @return
 	 */
 	public static String getPrefix() {
-        String prefix = PropertiesComponent.getInstance().getValue(Settings.PREFIX);
-        if (prefix == null || prefix.length() == 0) {
-            CodeStyleSettingsManager manager = CodeStyleSettingsManager.getInstance();
-            CodeStyleSettings settings = manager.getCurrentSettings();
-            prefix = settings.FIELD_NAME_PREFIX;
-        }
-		if (prefix == null || prefix.length() == 0) {
-			prefix = "m"; // field name
+		if (PropertiesComponent.getInstance().isValueSet(Settings.PREFIX)) {
+			return PropertiesComponent.getInstance().getValue(Settings.PREFIX);
+		} else {
+			CodeStyleSettingsManager manager = CodeStyleSettingsManager.getInstance();
+			CodeStyleSettings settings = manager.getCurrentSettings();
+			return settings.FIELD_NAME_PREFIX;
 		}
-		return prefix;
 	}
 
-    public static String getViewHolderClassName() {
-        return PropertiesComponent.getInstance().getValue(Settings.VIEWHOLDER_CLASS_NAME, "ViewHolder");
-    }
+	public static String getViewHolderClassName() {
+		return PropertiesComponent.getInstance().getValue(Settings.VIEWHOLDER_CLASS_NAME, "ViewHolder");
+	}
 
 	/**
 	 * Parse ID of injected element (eg. R.id.text)

--- a/src/eu/inmite/android/plugin/butterknifezelezny/model/Element.java
+++ b/src/eu/inmite/android/plugin/butterknifezelezny/model/Element.java
@@ -72,10 +72,12 @@ public class Element {
 		StringBuilder sb = new StringBuilder();
 		sb.append(Utils.getPrefix());
 
-		for (String word : words) {
-			String[] idTokens = word.split("\\.");
+		for (int i = 0; i < words.length; i++) {
+			String[] idTokens = words[i].split("\\.");
 			char[] chars = idTokens[idTokens.length - 1].toCharArray();
-			chars[0] = Character.toUpperCase(chars[0]);
+			if (i > 0 || !Utils.isEmptyString(Utils.getPrefix())) {
+			    chars[0] = Character.toUpperCase(chars[0]);
+			}
 
 			sb.append(chars);
 		}


### PR DESCRIPTION
Do not set 'm' as a default member prefix if a user leaves it empty in the settings.

Fixes #24.
