### PR TITLE
Avoid auto-generating methods if already present in parent classes

### DIFF
--- a/src/com/avast/android/butterknifezelezny/InjectWriter.java
+++ b/src/com/avast/android/butterknifezelezny/InjectWriter.java
@@ -270,46 +270,14 @@ public class InjectWriter extends WriteCommandAction.Simple {
     private void generateActivityBind(@NotNull IButterKnife butterKnife) {
         PsiMethod[] onCreateMethods = mClass.findMethodsByName("onCreate", true);
         if (onCreateMethods.length == 1) { // only AOSP implementation found
-            // Add an empty stub of onCreate()
-            StringBuilder method = new StringBuilder();
-            method.append("@Override protected void onCreate(android.os.Bundle savedInstanceState) {\n");
-            method.append("super.onCreate(savedInstanceState);\n");
-            method.append("\t// TODO: add setContentView(...) invocation\n");
-            method.append(butterKnife.getCanonicalBindStatement());
-            method.append("(this);\n");
-            method.append("}");
-
-            mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+            createOncreateWithBind(butterKnife);
         } else {
             if (!containsButterKnifeInjectLine(onCreateMethods, butterKnife.getSimpleBindStatement())) {
                 PsiMethod[] onCreateMethodsWithoutBaseClass = mClass.findMethodsByName("onCreate", false);
                 if (onCreateMethodsWithoutBaseClass.length == 0) { // No method found in current file
-                    // Add an empty stub of onCreate()
-                    StringBuilder method = new StringBuilder();
-                    method.append("@Override protected void onCreate(android.os.Bundle savedInstanceState) {\n");
-                    method.append("super.onCreate(savedInstanceState);\n");
-                    method.append("\t// TODO: add setContentView(...) invocation\n");
-                    method.append(butterKnife.getCanonicalBindStatement());
-                    method.append("(this);\n");
-                    method.append("}");
-
-                    mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+                    createOncreateWithBind(butterKnife);
                 } else {
-                    PsiMethod onCreate = onCreateMethodsWithoutBaseClass[0];
-                    for (PsiStatement statement : onCreate.getBody().getStatements()) {
-                        // Search for setContentView()
-                        if (statement.getFirstChild() instanceof PsiMethodCallExpression) {
-                            PsiReferenceExpression methodExpression
-                                    = ((PsiMethodCallExpression) statement.getFirstChild())
-                                    .getMethodExpression();
-                            // Insert ButterKnife.inject()/ButterKnife.bind() after setContentView()
-                            if (methodExpression.getText().equals("setContentView")) {
-                                onCreate.getBody().addAfter(mFactory.createStatementFromText(
-                                        butterKnife.getCanonicalBindStatement() + "(this);", mClass), statement);
-                                break;
-                            }
-                        }
-                    }
+                    addBindToOncreate(butterKnife, onCreateMethodsWithoutBaseClass[0]);
                 }
             }
         }
@@ -323,78 +291,14 @@ public class InjectWriter extends WriteCommandAction.Simple {
 
         PsiMethod[] onCreateViewMethods = mClass.findMethodsByName("onCreateView", true);
         if (onCreateViewMethods.length == 1) { // only AOSP implementation found
-            // Add an empty stub of onCreateView()
-            StringBuilder method = new StringBuilder();
-            method.append("@Override public View onCreateView(android.view.LayoutInflater inflater, android.view.ViewGroup container, android.os.Bundle savedInstanceState) {\n");
-            method.append("\t// TODO: inflate a fragment view\n");
-            method.append("android.view.View rootView = super.onCreateView(inflater, container, savedInstanceState);\n");
-            if (butterKnife.isUsingUnbinder()) {
-                method.append(unbinderName);
-                method.append(" = ");
-            }
-            method.append(butterKnife.getCanonicalBindStatement());
-            method.append("(this, rootView);\n");
-            method.append("return rootView;\n");
-            method.append("}");
-
-            mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+            createOncreateviewWithBind(butterKnife, unbinderName);
         } else {
             if (!containsButterKnifeInjectLine(onCreateViewMethods, butterKnife.getSimpleBindStatement())) {
                 PsiMethod[] onCreateViewMethodsWithoutBaseClass = mClass.findMethodsByName("onCreateView", false);
                 if (onCreateViewMethodsWithoutBaseClass.length == 0) { // No method found in current file
-                    // Add an empty stub of onCreateView()
-                    StringBuilder method = new StringBuilder();
-                    method.append("@Override public View onCreateView(android.view.LayoutInflater inflater, android.view.ViewGroup container, android.os.Bundle savedInstanceState) {\n");
-                    method.append("\t// TODO: inflate a fragment view\n");
-                    method.append("android.view.View rootView = super.onCreateView(inflater, container, savedInstanceState);\n");
-                    if (butterKnife.isUsingUnbinder()) {
-                        method.append(unbinderName);
-                        method.append(" = ");
-                    }
-                    method.append(butterKnife.getCanonicalBindStatement());
-                    method.append("(this, rootView);\n");
-                    method.append("return rootView;\n");
-                    method.append("}");
-
-                    mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+                    createOncreateviewWithBind(butterKnife, unbinderName);
                 } else {
-                    // onCreateView() exists, let's update it with an inject/bind statement
-                    PsiMethod onCreateView = onCreateViewMethodsWithoutBaseClass[0];
-                    if (!containsButterKnifeInjectLine(onCreateView, butterKnife.getSimpleBindStatement())) {
-                        for (PsiStatement statement : onCreateView.getBody().getStatements()) {
-                            if (statement instanceof PsiReturnStatement) {
-                                String returnValue = ((PsiReturnStatement) statement).getReturnValue().getText();
-                                // there's layout inflation
-                                if (returnValue.contains("R.layout")) {
-                                    onCreateView.getBody().addBefore(mFactory.createStatementFromText("android.view.View view = " + returnValue + ";", mClass), statement);
-                                    StringBuilder bindText = new StringBuilder();
-                                    if (butterKnife.isUsingUnbinder()) {
-                                        bindText.append(unbinderName);
-                                        bindText.append(" = ");
-                                    }
-                                    bindText.append(butterKnife.getCanonicalBindStatement());
-                                    bindText.append("(this, view);");
-                                    PsiStatement bindStatement = mFactory.createStatementFromText(bindText.toString(), mClass);
-                                    onCreateView.getBody().addBefore(bindStatement, statement);
-                                    statement.replace(mFactory.createStatementFromText("return view;", mClass));
-                                } else {
-                                    // Insert ButterKnife.inject()/ButterKnife.bind() before returning a view for a fragment
-                                    StringBuilder bindText = new StringBuilder();
-                                    if (butterKnife.isUsingUnbinder()) {
-                                        bindText.append(unbinderName);
-                                        bindText.append(" = ");
-                                    }
-                                    bindText.append(butterKnife.getCanonicalBindStatement());
-                                    bindText.append("(this, ");
-                                    bindText.append(returnValue);
-                                    bindText.append(");");
-                                    PsiStatement bindStatement = mFactory.createStatementFromText(bindText.toString(), mClass);
-                                    onCreateView.getBody().addBefore(bindStatement, statement);
-                                }
-                                break;
-                            }
-                        }
-                    }
+                    addBindToOncreateview(butterKnife, unbinderName, onCreateViewMethodsWithoutBaseClass[0]);
                 }
             }
         }
@@ -403,29 +307,14 @@ public class InjectWriter extends WriteCommandAction.Simple {
         if (butterKnife.isUnbindSupported()) {
             PsiMethod[] onDestroyViewsMethods = mClass.findMethodsByName("onDestroyView", true);
             if (onDestroyViewsMethods.length == 1) { // only AOSP implementation found
-                StringBuilder method = new StringBuilder();
-                method.append("@Override public void onDestroyView() {\n");
-                method.append("super.onDestroyView();\n");
-                method.append(generateUnbindStatement(butterKnife, unbinderName, true));
-                method.append("}");
-
-                mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+                createOndestroyviewWithUnbind(butterKnife, unbinderName);
             } else {
                 if (!containsButterKnifeInjectLine(onDestroyViewsMethods, butterKnife.getSimpleUnbindStatement())) {
                     PsiMethod[] onDestroyViewMethodsWithoutBaseClass = mClass.findMethodsByName("onDestroyView", false);
                     if (onDestroyViewMethodsWithoutBaseClass.length == 0) { // No method found in current file
-                        StringBuilder method = new StringBuilder();
-                        method.append("@Override public void onDestroyView() {\n");
-                        method.append("super.onDestroyView();\n");
-                        method.append(generateUnbindStatement(butterKnife, unbinderName, true));
-                        method.append("}");
-
-                        mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
-                    } else { // there's already onDestroyView(), let's add the unbind statement
-                        PsiMethod onDestroyView = onDestroyViewsMethods[0];
-                        StringBuilder unbindText = generateUnbindStatement(butterKnife, unbinderName, false);
-                        final PsiStatement unbindStatement = mFactory.createStatementFromText(unbindText.toString(), mClass);
-                        onDestroyView.getBody().addBefore(unbindStatement, onDestroyView.getBody().getLastBodyElement());
+                        createOndestroyviewWithUnbind(butterKnife, unbinderName);
+                    } else {
+                        addUnbindToOndestroyview(butterKnife, unbinderName, onDestroyViewsMethods[0]);
                     }
                 }
             }
@@ -436,6 +325,105 @@ public class InjectWriter extends WriteCommandAction.Simple {
             String unbinderFieldText = butterKnife.getUnbinderClassCanonicalName() + " " + unbinderName + ";";
             mClass.add(mFactory.createFieldFromText(unbinderFieldText, mClass));
         }
+    }
+
+    private void createOncreateWithBind(@NotNull IButterKnife butterKnife) {
+        StringBuilder method = new StringBuilder();
+        method.append("@Override protected void onCreate(android.os.Bundle savedInstanceState) {\n");
+        method.append("super.onCreate(savedInstanceState);\n");
+        method.append("\t// TODO: add setContentView(...) invocation\n");
+        method.append(butterKnife.getCanonicalBindStatement());
+        method.append("(this);\n");
+        method.append("}");
+
+        mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+    }
+
+    private void addBindToOncreate(@NotNull IButterKnife butterKnife, PsiMethod onCreateMethod) {
+        for (PsiStatement statement : onCreateMethod.getBody().getStatements()) {
+            // Search for setContentView()
+            if (statement.getFirstChild() instanceof PsiMethodCallExpression) {
+                PsiReferenceExpression methodExpression
+                        = ((PsiMethodCallExpression) statement.getFirstChild()).getMethodExpression();
+                // Insert ButterKnife.inject()/ButterKnife.bind() after setContentView()
+                if (methodExpression.getText().equals("setContentView")) {
+                    onCreateMethod.getBody().addAfter(mFactory.createStatementFromText(
+                            butterKnife.getCanonicalBindStatement() + "(this);", mClass), statement);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void createOncreateviewWithBind(@NotNull IButterKnife butterKnife, String unbinderName) {
+        StringBuilder method = new StringBuilder();
+        method.append("@Override public View onCreateView(android.view.LayoutInflater inflater, android.view.ViewGroup container, android.os.Bundle savedInstanceState) {\n");
+        method.append("\t// TODO: inflate a fragment view\n");
+        method.append("android.view.View rootView = super.onCreateView(inflater, container, savedInstanceState);\n");
+        if (butterKnife.isUsingUnbinder()) {
+            method.append(unbinderName);
+            method.append(" = ");
+        }
+        method.append(butterKnife.getCanonicalBindStatement());
+        method.append("(this, rootView);\n");
+        method.append("return rootView;\n");
+        method.append("}");
+
+        mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+    }
+
+    private void addBindToOncreateview(@NotNull IButterKnife butterKnife, String unbinderName, PsiMethod onCreateView) {
+        if (!containsButterKnifeInjectLine(onCreateView, butterKnife.getSimpleBindStatement())) {
+            for (PsiStatement statement : onCreateView.getBody().getStatements()) {
+                if (statement instanceof PsiReturnStatement) {
+                    String returnValue = ((PsiReturnStatement) statement).getReturnValue().getText();
+                    // there's layout inflation
+                    if (returnValue.contains("R.layout")) {
+                        onCreateView.getBody().addBefore(mFactory.createStatementFromText("android.view.View view = " + returnValue + ";", mClass), statement);
+                        StringBuilder bindText = new StringBuilder();
+                        if (butterKnife.isUsingUnbinder()) {
+                            bindText.append(unbinderName);
+                            bindText.append(" = ");
+                        }
+                        bindText.append(butterKnife.getCanonicalBindStatement());
+                        bindText.append("(this, view);");
+                        PsiStatement bindStatement = mFactory.createStatementFromText(bindText.toString(), mClass);
+                        onCreateView.getBody().addBefore(bindStatement, statement);
+                        statement.replace(mFactory.createStatementFromText("return view;", mClass));
+                    } else {
+                        // Insert ButterKnife.inject()/ButterKnife.bind() before returning a view for a fragment
+                        StringBuilder bindText = new StringBuilder();
+                        if (butterKnife.isUsingUnbinder()) {
+                            bindText.append(unbinderName);
+                            bindText.append(" = ");
+                        }
+                        bindText.append(butterKnife.getCanonicalBindStatement());
+                        bindText.append("(this, ");
+                        bindText.append(returnValue);
+                        bindText.append(");");
+                        PsiStatement bindStatement = mFactory.createStatementFromText(bindText.toString(), mClass);
+                        onCreateView.getBody().addBefore(bindStatement, statement);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    private void createOndestroyviewWithUnbind(@NotNull IButterKnife butterKnife, String unbinderName) {
+        StringBuilder method = new StringBuilder();
+        method.append("@Override public void onDestroyView() {\n");
+        method.append("super.onDestroyView();\n");
+        method.append(generateUnbindStatement(butterKnife, unbinderName, true));
+        method.append("}");
+
+        mClass.add(mFactory.createMethodFromText(method.toString(), mClass));
+    }
+
+    private void addUnbindToOndestroyview(@NotNull IButterKnife butterKnife, String unbinderName, PsiMethod onDestroyView) {
+        StringBuilder unbindText = generateUnbindStatement(butterKnife, unbinderName, false);
+        final PsiStatement unbindStatement = mFactory.createStatementFromText(unbindText.toString(), mClass);
+        onDestroyView.getBody().addBefore(unbindStatement, onDestroyView.getBody().getLastBodyElement());
     }
 
     private static StringBuilder generateUnbindStatement(@NotNull IButterKnife butterKnife, String unbinderName,

--- a/test-app/app/src/main/AndroidManifest.xml
+++ b/test-app/app/src/main/AndroidManifest.xml
@@ -15,6 +15,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".InheritanceActivity"
+            android:label="@string/app_name" >
+        </activity>
     </application>
 
 </manifest>

--- a/test-app/app/src/main/java/com/avast/butterknifezelezny/test/BaseActivity.java
+++ b/test-app/app/src/main/java/com/avast/butterknifezelezny/test/BaseActivity.java
@@ -1,0 +1,17 @@
+package com.avast.butterknifezelezny.test;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import butterknife.ButterKnife;
+
+public abstract class BaseActivity extends ActionBarActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(getLayoutId());
+        ButterKnife.bind(this);
+    }
+
+    protected abstract int getLayoutId();
+}

--- a/test-app/app/src/main/java/com/avast/butterknifezelezny/test/BaseFragment.java
+++ b/test-app/app/src/main/java/com/avast/butterknifezelezny/test/BaseFragment.java
@@ -1,0 +1,33 @@
+package com.avast.butterknifezelezny.test;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import butterknife.Unbinder;
+
+public abstract class BaseFragment extends Fragment {
+
+    public BaseFragment() {
+    }
+
+    private Unbinder unbinder;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(getLayoutId(), container, false);
+        unbinder = butterknife.ButterKnife.bind(this, view);
+        return view;
+    }
+
+    protected abstract int getLayoutId();
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
+    }
+
+}

--- a/test-app/app/src/main/java/com/avast/butterknifezelezny/test/InheritanceActivity.java
+++ b/test-app/app/src/main/java/com/avast/butterknifezelezny/test/InheritanceActivity.java
@@ -1,0 +1,23 @@
+package com.avast.butterknifezelezny.test;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+
+public class InheritanceActivity extends BaseActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .add(R.id.container, new Fragment())
+                    .commit();
+        }
+    }
+
+    @Override
+    protected int getLayoutId() {
+        // Try to generate Activity injections by clicking to R.layout.activity_main
+        return R.layout.activity_main;
+    }
+}

--- a/test-app/app/src/main/java/com/avast/butterknifezelezny/test/InheritanceFragment.java
+++ b/test-app/app/src/main/java/com/avast/butterknifezelezny/test/InheritanceFragment.java
@@ -1,0 +1,13 @@
+package com.avast.butterknifezelezny.test;
+
+public class InheritanceFragment extends BaseFragment {
+
+    public InheritanceFragment() {
+    }
+
+    @Override
+    protected int getLayoutId() {
+        // Try to generate Fragment injections by clicking to R.layout.fragment_main
+        return R.layout.fragment_main;
+    }
+}


### PR DESCRIPTION
Hi @TomasKypta, this PR solves issues #68, #74, #82, #100, #108 following @NikolaDespotoski's explanation here #74.

Behaviour followed has been:
**1**. find method (_onCreate_/_onCreateView_/_onDestroyView_) in current class **and** superclasses.
**1.a**. if list returned has size 1, that means that the only method found is the Android code base one. Then, add method in current class with _bind_/_unbind_.
**1.b**. otherwise
**1.b.1**. if no methods from **1** (that is to say, current class **and** superclasses) has ButterKnife _bind_/_unbind_ declared.
**1.b.1.1**. find method **only in current** class
**1.b.1.1.a**. if method is found, just add _bind_/_unbind_.
**1.b.1.1.b**. otherwise, add method with _bind_/_unbind_.
**1.b.2**. otherwise, no action is needed

_(not sure if it's the best explanation that way, maybe a flow chart would have been better)._