### PR TITLE
Added custom naming functionality

### DIFF
--- a/src/com/avast/android/butterknifezelezny/Settings.form
+++ b/src/com/avast/android/butterknifezelezny/Settings.form
@@ -19,7 +19,7 @@
           <forms/>
         </constraints>
         <properties>
-          <text value="Prefix for generated members:"/>
+          <text value="Naming for generated members:"/>
         </properties>
       </component>
       <component id="901" class="javax.swing.JLabel">
@@ -38,7 +38,9 @@
           </grid>
           <forms defaultalign-horz="false"/>
         </constraints>
-        <properties/>
+        <properties>
+          <toolTipText value="Use ${ID} for name and ${TYPE} for type"/>
+        </properties>
       </component>
       <component id="52c12" class="javax.swing.JTextField" binding="mHolderName">
         <constraints>

--- a/src/com/avast/android/butterknifezelezny/model/Element.java
+++ b/src/com/avast/android/butterknifezelezny/model/Element.java
@@ -71,20 +71,19 @@ public class Element {
      */
     private String getFieldName() {
         String[] words = this.id.split("_");
-        StringBuilder sb = new StringBuilder();
-        sb.append(Utils.getPrefix());
+        StringBuilder nameFromID = new StringBuilder();
 
         for (int i = 0; i < words.length; i++) {
             String[] idTokens = words[i].split("\\.");
             char[] chars = idTokens[idTokens.length - 1].toCharArray();
-            if (i > 0 || !Utils.isEmptyString(Utils.getPrefix())) {
+            if (i > 0 && !Utils.isEmptyString(Utils.getPrefix())) {
                 chars[0] = Character.toUpperCase(chars[0]);
             }
 
-            sb.append(chars);
+            nameFromID.append(chars);
         }
 
-        return sb.toString();
+        return (Utils.isEmptyString(Utils.getPrefix())) ? nameFromID.toString() : Utils.getPrefix().replace("${ID}", nameFromID).replace("${TYPE}", name);
     }
 
     /**


### PR DESCRIPTION
As per issue #80 and @TomasKypta suggestions I've changed Settings naming field and enabled custom naming for generated members by using ${ID} and ${TYPE} for name from ID and class name respectively 